### PR TITLE
Add heap_set_event_properties

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -30,7 +30,7 @@ Heap needs your application ID to successfully submit data to heapanalytics.com.
 
 ### Identifying your users
 
-The `heap_identify` view helper can be used to supply heap with attributes for your users. The helper takes 2 arguments: 
+The `heap_identify` view helper can be used to supply heap with attributes for your users. The helper takes 2 arguments:
 
 * [String] email: The e-mail address used to identify your visitor in Heap
 * [Hash, optional] properties: A hash containing additional properties for your users (Hashes with multiple levels are currently not supported)
@@ -42,6 +42,12 @@ Example:
 If you wish to use a different handle type, only `handle`/`email` are supported at the time of writing, you can set it using `Heap.default_handle_type = 'handle'`.
 
 Default is set to `email`.
+
+### Adding custom event properties
+
+With `heap_set_event_properties`, you can specify key-value pairs to associate with all of a user's subsequent events. This helper takes one argument:
+
+* [Hash] properties: A hash containing all of the properties you want to attach to the user's events
 
 ### Tracking server-side events
 
@@ -55,7 +61,7 @@ Example:
 
     Heap.event("Welcome e-mail sent", "user@example.com", promotion:'second gem free', segment:'ruby developers')
 
-### Adding server-side user attributes 
+### Adding server-side user attributes
 
 To update or set properties on your users directly from your application, use `Heap.identify`. `Heap.identify` takes 2 arguments:
 
@@ -67,7 +73,7 @@ Example:
     Heap.identify("user@example.com", segment:'ruby developers', age: 25)
 
 ## Contributing to Heap
- 
+
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.
 * Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it.
 * Fork the project.

--- a/lib/heap/view_helpers.rb
+++ b/lib/heap/view_helpers.rb
@@ -1,18 +1,26 @@
+require 'json'
+
 class Heap
   module ViewHelpers
     def heap_analytics
-      javascript_tag :type => "text/javascript" do
-        raw %Q{
-          window.heap=window.heap||[],heap.load=function(t,e){window.heap.appid=t,window.heap.config=e;var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+t+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(t){return function(){heap.push([t].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
-          heap.load("#{Heap.app_id}");
-          }.html_safe
-      end
+      heap_js_block %Q{
+        window.heap=window.heap||[],heap.load=function(t,e){window.heap.appid=t,window.heap.config=e;var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+t+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(t){return function(){heap.push([t].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+        heap.load("#{Heap.app_id}");
+      }
     end
 
     def heap_identify(handle, properties = nil)
       body = properties.map {|k,v| ", #{k}: \"#{v}\""}.join if properties.is_a? Hash
-      javascript_tag do
-        raw %Q{heap.identify({#{Heap.default_handle_type}: "#{handle}" #{body}});}.html_safe
+      heap_js_block %Q{heap.identify({#{Heap.default_handle_type}: "#{handle}" #{body}});}
+    end
+
+    def heap_set_event_properties(properties = {})
+      heap_js_block %Q{heap.setEventProperties(#{properties.to_json});}
+    end
+
+    def heap_js_block(content)
+      javascript_tag :type => "text/javascript" do
+        raw content.html_safe
       end
     end
   end

--- a/test/test_view_helper.rb
+++ b/test/test_view_helper.rb
@@ -9,16 +9,17 @@ end
 class HeapHelperTest < MiniTest::Test
   include Heap::ViewHelpers
 
-  should "produce correct identify handle type" #do
-    # handle = '123'
-    # assert_equal heap_identify(handle), "heap.identify({email: \"#{handle}\" });"
-  # end
   def javascript_tag(options = {})
     yield
   end
 
   def raw(js)
     js
+  end
+
+  should "produce correct identify handle type" do
+    handle = '123'
+    assert_equal heap_identify(handle), "heap.identify({email: \"#{handle}\" });"
   end
 
   should "set event properties from arbitrary key-value pairs" do

--- a/test/test_view_helper.rb
+++ b/test/test_view_helper.rb
@@ -1,5 +1,11 @@
 require 'helper'
 
+class String
+  def html_safe
+    self
+  end
+end
+
 class HeapHelperTest < MiniTest::Test
   include Heap::ViewHelpers
 
@@ -7,4 +13,21 @@ class HeapHelperTest < MiniTest::Test
     # handle = '123'
     # assert_equal heap_identify(handle), "heap.identify({email: \"#{handle}\" });"
   # end
+  def javascript_tag(options = {})
+    yield
+  end
+
+  def raw(js)
+    js
+  end
+
+  should "set event properties from arbitrary key-value pairs" do
+    js = heap_set_event_properties({
+      :first => "first value",
+      "second" => 2,
+      :third => true
+    })
+
+    assert_equal js, %Q/heap.setEventProperties({"first":"first value","second":2,"third":true});/
+  end
 end


### PR DESCRIPTION
Implements #3. This adds a `heap_set_event_properties` helper, plus a test and an explanation in `README.mdown`.

I noticed that the "produce correct identify handle type" test was commented out, which seemed to be because it wouldn't work with the Rails-specific functions needed by `ViewHelpers`. It wasn't hard to make it work, so I did that too.
