### PR TITLE
New Heap script that allows for advanced configuration options

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -72,6 +72,16 @@ Example:
 
     Heap.identify("user@example.com", segment:'ruby developers', age: 25)
 
+### Advanced load configuration
+
+When calling 'heap_analytics', you may set additional advanced configuration options (such as secure cookies, enabling SSL, and disabling text capture). The helper takes an optional argument:
+
+* [Hash, optional] properties: A hash containing additional configuration options (Hashes with multiple levels are currently not supported)
+
+Example:
+
+      <%= heap_analytics(forceSSL: true, secureCookie: true, disableTextCapture: true) %>
+
 ## Contributing to Heap
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.
@@ -87,4 +97,3 @@ Example:
 The Heap gem is licensed under the MIT license. Copyright (c) 2014 Dennis de Reus. See LICENSE.txt for further details.
 
 The Heap gem is a personal project and not affiliated to heapanalytics.com
-

--- a/lib/heap/view_helpers.rb
+++ b/lib/heap/view_helpers.rb
@@ -2,10 +2,11 @@ require 'json'
 
 class Heap
   module ViewHelpers
-    def heap_analytics
+    def heap_analytics(properties = {})
+      config = properties.map {|k,v| "#{k}: #{v}"}.join(", ") if properties.is_a? Hash
       heap_js_block %Q{
-        window.heap=window.heap||[],heap.load=function(t,e){window.heap.appid=t,window.heap.config=e;var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+t+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(t){return function(){heap.push([t].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
-        heap.load("#{Heap.app_id}");
+        window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var n=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(n?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(a,o);for(var r=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=r(p[c])};
+        heap.load("#{Heap.app_id}", {#{config}});
       }
     end
 

--- a/test/test_view_helper.rb
+++ b/test/test_view_helper.rb
@@ -31,4 +31,17 @@ class HeapHelperTest < MiniTest::Test
 
     assert_equal js, %Q/heap.setEventProperties({"first":"first value","second":2,"third":true});/
   end
+
+  should "set load properties key-value pairs" do
+
+    Heap.app_id = '123'
+
+    js = heap_analytics({
+      forceSSL: true,
+      secureCookie: true,
+      disableTextCapture: true
+    })
+
+    assert_includes js, %Q/heap.load("123", {forceSSL: true, secureCookie: true, disableTextCapture: true});/
+  end
 end


### PR DESCRIPTION
Looking at the Heap [install documentation](https://heapanalytics.com/docs/installation), there appears to be an updated script. (Look for the forceSSL option, which is about one screen's-width to the right in the diff below and on the Heap site...)

Additionally, I added support for three available options on Heap.load: forceSSL, secureCookie, and disableTextCapture (listed at the bottom of install documentation above).
